### PR TITLE
大佬，发现您的项目引入了com.alibaba:fastjson@1.2.17组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.halo</groupId>
@@ -12,11 +10,11 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.0.9.RELEASE</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>
-        <fastjson.version>1.2.17</fastjson.version>
+        <fastjson.version>1.2.69</fastjson.version>
         <rule-core.version>4.1.0</rule-core.version>
     </properties>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Fastjson <=1.2.68 远程代码执行漏洞
缺陷组件：com.alibaba:fastjson@1.2.17
漏洞编号：
漏洞描述：Fastjson 是Java语言实现的快速JSON解析和生成器，在<=1.2.68的版本中攻击者可通过精心构造的JSON请求，远程执行恶意代码。
漏洞原因：
Fastjson采用黑白名单的方法来防御反序列化漏洞，导致当黑客不断发掘新的反序列化Gadgets类时，发现在autoType关闭的情况下仍然可能可以绕过黑白名单防御机制，造成远程命令执行漏洞。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2020-30827
影响范围：(∞, 1.2.69)
最小修复版本：1.2.69
缺陷组件引入路径：com.halo:halo-easy-rules@1.0-SNAPSHOT->com.alibaba:fastjson@1.2.17
```
另外我运行这个项目时，IDE的安全插件提示还有82个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p2c43d